### PR TITLE
Feat/migrate gg retry role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,6 @@ update-owners-and-guardians:
 
 update-ccc-permissions:
 	$(call deploy_fn,helpers/UpdateCCCPermissions,megaeth)
+
+gg-retry-role-migration:
+	$(call deploy_fn,payloads/gg/GG_retry_role_migration,ethereum)

--- a/foundry.lock
+++ b/foundry.lock
@@ -5,7 +5,7 @@
   "lib/aave-helpers": {
     "branch": {
       "name": "main",
-      "rev": "0459d4ef721c6306a194a36a559a8462f9b19633"
+      "rev": "a7799378dde2c630298a177fd9f600b2d34e27fc"
     }
   }
 }

--- a/scripts/payloads/gg/GG_retry_role_migration.s.sol
+++ b/scripts/payloads/gg/GG_retry_role_migration.s.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {
+  RetryRoleMigrationPayload,
+  GGRetryRoleMigrationArgs
+} from '../../../src/gg_payloads/RetryRoleMigrationPayload.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {GovernanceV3Arbitrum} from 'aave-address-book/GovernanceV3Arbitrum.sol';
+import {GovernanceV3Avalanche} from 'aave-address-book/GovernanceV3Avalanche.sol';
+import {GovernanceV3Base} from 'aave-address-book/GovernanceV3Base.sol';
+import {GovernanceV3BNB} from 'aave-address-book/GovernanceV3BNB.sol';
+import {GovernanceV3Bob} from 'aave-address-book/GovernanceV3Bob.sol';
+import {GovernanceV3Celo} from 'aave-address-book/GovernanceV3Celo.sol';
+import {GovernanceV3Scroll} from 'aave-address-book/GovernanceV3Scroll.sol';
+import {GovernanceV3Sonic} from 'aave-address-book/GovernanceV3Sonic.sol';
+import {GovernanceV3Xlayer} from 'aave-address-book/GovernanceV3Xlayer.sol';
+import {GovernanceV3Megaeth} from 'aave-address-book/GovernanceV3Megaeth.sol';
+import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
+import {GovernanceV3Plasma} from 'aave-address-book/GovernanceV3Plasma.sol';
+import {GovernanceV3Polygon} from 'aave-address-book/GovernanceV3Polygon.sol';
+import {GovernanceV3Mantle} from 'aave-address-book/GovernanceV3Mantle.sol';
+import {GovernanceV3Line} from 'aave-address-book/GovernanceV3Line.sol';
+import {GovernanceV3Ink} from 'aave-address-book/GovernanceV3Ink.sol';
+import {GovernanceV3Gnosis} from 'aave-address-book/GovernanceV3Gnosis.sol';
+
+abstract contract GG_retry_role_migration is BaseDeployerScript {
+  function PAYLOAD_SALT() internal pure virtual returns (string memory) {
+    return 'GG retry role migration';
+  }
+
+  function GRANULAR_GUARDIAN() internal pure virtual returns (address);
+
+  function NEW_RETRY_GUARDIAN() internal pure virtual returns (address);
+
+  function _deployPayload(GGRetryRoleMigrationArgs memory args) internal returns (address) {
+    bytes memory payloadByteCode = type(RetryRoleMigrationPayload).creationCode;
+    bytes memory payloadCode = abi.encodePacked(payloadByteCode, abi.encode(args));
+
+    return _deployByteCode(payloadCode, PAYLOAD_SALT());
+  }
+
+  function _execute(Addresses memory addresses) internal virtual override {
+    _deployPayload(
+      GGRetryRoleMigrationArgs({
+        granularGuardian: GRANULAR_GUARDIAN(),
+        newRetryGuardian: NEW_RETRY_GUARDIAN()
+      })
+    );
+  }
+}
+
+contract Arbitrum is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Arbitrum.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Avalanche is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Avalanche.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Base is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Base.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Binance is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3BNB.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Bob is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Bob.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Celo is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Celo.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Ethereum is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Ethereum.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Gnosis is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Gnosis.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Ink is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Ink.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Linea is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Line.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Mantle is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Mantle.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Megaeth is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Megaeth.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+// contract Metis is GG_retry_role_migration {
+//   function GRANULAR_GUARDIAN() internal pure override returns (address) {
+//     return GovernanceV3Metis.GRANULAR_GUARDIAN;
+//   }
+
+//   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+//   }
+// }
+
+contract Optimism is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Optimism.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Plasma is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Plasma.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Polygon is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Polygon.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Scroll is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Scroll.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+// contract Soneium is GG_retry_role_migration {
+//   function GRANULAR_GUARDIAN() internal pure override returns (address) {
+//     return GovernanceV3Soneium.GRANULAR_GUARDIAN;
+//   }
+
+//   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+//   }
+// }
+
+contract Sonic is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Sonic.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+contract Xlayer is GG_retry_role_migration {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Xlayer.GRANULAR_GUARDIAN;
+  }
+
+  function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+}
+
+// contract Zksync is GG_retry_role_migration {
+//   function GRANULAR_GUARDIAN() internal pure override returns (address) {
+//     return GovernanceV3ZkSync.GRANULAR_GUARDIAN;
+//   }
+
+//   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+//   }
+// }

--- a/scripts/payloads/gg/GG_retry_role_migration.s.sol
+++ b/scripts/payloads/gg/GG_retry_role_migration.s.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+
+import '../../BaseDeployerScript.sol';
 import {
   RetryRoleMigrationPayload,
   GGRetryRoleMigrationArgs
@@ -14,15 +16,16 @@ import {GovernanceV3Bob} from 'aave-address-book/GovernanceV3Bob.sol';
 import {GovernanceV3Celo} from 'aave-address-book/GovernanceV3Celo.sol';
 import {GovernanceV3Scroll} from 'aave-address-book/GovernanceV3Scroll.sol';
 import {GovernanceV3Sonic} from 'aave-address-book/GovernanceV3Sonic.sol';
-import {GovernanceV3Xlayer} from 'aave-address-book/GovernanceV3Xlayer.sol';
-import {GovernanceV3Megaeth} from 'aave-address-book/GovernanceV3Megaeth.sol';
+import {GovernanceV3XLayer} from 'aave-address-book/GovernanceV3XLayer.sol';
+import {GovernanceV3MegaEth} from 'aave-address-book/GovernanceV3MegaEth.sol';
 import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
 import {GovernanceV3Plasma} from 'aave-address-book/GovernanceV3Plasma.sol';
 import {GovernanceV3Polygon} from 'aave-address-book/GovernanceV3Polygon.sol';
 import {GovernanceV3Mantle} from 'aave-address-book/GovernanceV3Mantle.sol';
-import {GovernanceV3Line} from 'aave-address-book/GovernanceV3Line.sol';
+import {GovernanceV3Linea} from 'aave-address-book/GovernanceV3Linea.sol';
 import {GovernanceV3Ink} from 'aave-address-book/GovernanceV3Ink.sol';
 import {GovernanceV3Gnosis} from 'aave-address-book/GovernanceV3Gnosis.sol';
+
 
 abstract contract GG_retry_role_migration is BaseDeployerScript {
   function PAYLOAD_SALT() internal pure virtual returns (string memory) {
@@ -142,7 +145,7 @@ contract Ink is GG_retry_role_migration {
 
 contract Linea is GG_retry_role_migration {
   function GRANULAR_GUARDIAN() internal pure override returns (address) {
-    return GovernanceV3Line.GRANULAR_GUARDIAN;
+    return GovernanceV3Linea.GRANULAR_GUARDIAN;
   }
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
@@ -162,7 +165,7 @@ contract Mantle is GG_retry_role_migration {
 
 contract Megaeth is GG_retry_role_migration {
   function GRANULAR_GUARDIAN() internal pure override returns (address) {
-    return GovernanceV3Megaeth.GRANULAR_GUARDIAN;
+    return GovernanceV3MegaEth.GRANULAR_GUARDIAN;
   }
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
@@ -242,7 +245,7 @@ contract Sonic is GG_retry_role_migration {
 
 contract Xlayer is GG_retry_role_migration {
   function GRANULAR_GUARDIAN() internal pure override returns (address) {
-    return GovernanceV3Xlayer.GRANULAR_GUARDIAN;
+    return GovernanceV3XLayer.GRANULAR_GUARDIAN;
   }
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {

--- a/scripts/payloads/gg/GG_retry_role_migration.s.sol
+++ b/scripts/payloads/gg/GG_retry_role_migration.s.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-
 import '../../BaseDeployerScript.sol';
 import {
   RetryRoleMigrationPayload,
@@ -25,7 +24,6 @@ import {GovernanceV3Mantle} from 'aave-address-book/GovernanceV3Mantle.sol';
 import {GovernanceV3Linea} from 'aave-address-book/GovernanceV3Linea.sol';
 import {GovernanceV3Ink} from 'aave-address-book/GovernanceV3Ink.sol';
 import {GovernanceV3Gnosis} from 'aave-address-book/GovernanceV3Gnosis.sol';
-
 
 abstract contract GG_retry_role_migration is BaseDeployerScript {
   function PAYLOAD_SALT() internal pure virtual returns (string memory) {
@@ -61,6 +59,10 @@ contract Arbitrum is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.ARBITRUM;
+  }
 }
 
 contract Avalanche is GG_retry_role_migration {
@@ -70,6 +72,10 @@ contract Avalanche is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.AVALANCHE;
   }
 }
 
@@ -81,6 +87,10 @@ contract Base is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.BASE;
+  }
 }
 
 contract Binance is GG_retry_role_migration {
@@ -90,6 +100,10 @@ contract Binance is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.BNB;
   }
 }
 
@@ -101,6 +115,10 @@ contract Bob is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.BOB;
+  }
 }
 
 contract Celo is GG_retry_role_migration {
@@ -110,6 +128,10 @@ contract Celo is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.CELO;
   }
 }
 
@@ -121,6 +143,10 @@ contract Ethereum is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.ETHEREUM;
+  }
 }
 
 contract Gnosis is GG_retry_role_migration {
@@ -130,6 +156,10 @@ contract Gnosis is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.GNOSIS;
   }
 }
 
@@ -141,6 +171,10 @@ contract Ink is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.INK;
+  }
 }
 
 contract Linea is GG_retry_role_migration {
@@ -150,6 +184,10 @@ contract Linea is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.LINEA;
   }
 }
 
@@ -161,6 +199,10 @@ contract Mantle is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.MANTLE;
+  }
 }
 
 contract Megaeth is GG_retry_role_migration {
@@ -170,6 +212,10 @@ contract Megaeth is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.MEGAETH;
   }
 }
 
@@ -191,6 +237,10 @@ contract Optimism is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.OPTIMISM;
+  }
 }
 
 contract Plasma is GG_retry_role_migration {
@@ -200,6 +250,10 @@ contract Plasma is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.PLASMA;
   }
 }
 
@@ -211,6 +265,10 @@ contract Polygon is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.POLYGON;
+  }
 }
 
 contract Scroll is GG_retry_role_migration {
@@ -220,6 +278,10 @@ contract Scroll is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.SCROLL;
   }
 }
 
@@ -241,6 +303,10 @@ contract Sonic is GG_retry_role_migration {
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
   }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.SONIC;
+  }
 }
 
 contract Xlayer is GG_retry_role_migration {
@@ -250,6 +316,10 @@ contract Xlayer is GG_retry_role_migration {
 
   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+  }
+
+  function TRANSACTION_NETWORK() internal pure override returns (uint256) {
+    return ChainIds.XLAYER;
   }
 }
 

--- a/src/gg_payloads/RetryRoleMigrationPayload.sol
+++ b/src/gg_payloads/RetryRoleMigrationPayload.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {
   GranularGuardianAccessControl
-} from 'aave-delivery-infrastructure/contracts/access_control/GranularGuardianAccessControl.sol';
+} from 'adi/access_control/GranularGuardianAccessControl.sol';
 
 struct GGRetryRoleMigrationArgs {
   address granularGuardian;

--- a/src/gg_payloads/RetryRoleMigrationPayload.sol
+++ b/src/gg_payloads/RetryRoleMigrationPayload.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {
+  GranularGuardianAccessControl
+} from 'aave-delivery-infrastructure/contracts/access_control/GranularGuardianAccessControl.sol';
+
+struct GGRetryRoleMigrationArgs {
+  address granularGuardian;
+  address newRetryGuardian;
+}
+
+contract RetryRoleMigrationPayload {
+  address public immutable GRANULAR_GUARDIAN;
+  address public immutable NEW_RETRY_GUARDIAN;
+
+  constructor(GGRetryRoleMigrationArgs memory args) {
+    GRANULAR_GUARDIAN = args.granularGuardian;
+    NEW_RETRY_GUARDIAN = args.newRetryGuardian;
+  }
+
+  function execute() public {
+    // Get the current retry role guardian
+    address oldRetryRoleGuardian = GranularGuardianAccessControl(GRANULAR_GUARDIAN).getRoleAdmin(
+      GranularGuardianAccessControl.RETRY_ROLE()
+    );
+
+    // Grant the new guardian the retry role
+    GranularGuardianAccessControl(GRANULAR_GUARDIAN).grantRole(
+      GranularGuardianAccessControl.RETRY_ROLE(),
+      NEW_RETRY_GUARDIAN
+    );
+
+    // Revoke retry role from the old guardian
+    GranularGuardianAccessControl(GRANULAR_GUARDIAN).revokeRole(
+      GranularGuardianAccessControl.RETRY_ROLE(),
+      oldRetryRoleGuardian
+    );
+  }
+}

--- a/src/gg_payloads/RetryRoleMigrationPayload.sol
+++ b/src/gg_payloads/RetryRoleMigrationPayload.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {
-  GranularGuardianAccessControl
-} from 'adi/access_control/GranularGuardianAccessControl.sol';
+import {GranularGuardianAccessControl} from 'adi/access_control/GranularGuardianAccessControl.sol';
 
 struct GGRetryRoleMigrationArgs {
   address granularGuardian;
@@ -20,21 +18,16 @@ contract RetryRoleMigrationPayload {
   }
 
   function execute() public {
-    // Get the current retry role guardian
-    address oldRetryRoleGuardian = GranularGuardianAccessControl(GRANULAR_GUARDIAN).getRoleAdmin(
-      GranularGuardianAccessControl.RETRY_ROLE()
+    GranularGuardianAccessControl granularGuardian = GranularGuardianAccessControl(
+      GRANULAR_GUARDIAN
     );
+    // Get the current retry role guardian
+    address oldRetryRoleGuardian = granularGuardian.getRoleMember(granularGuardian.RETRY_ROLE(), 0);
 
     // Grant the new guardian the retry role
-    GranularGuardianAccessControl(GRANULAR_GUARDIAN).grantRole(
-      GranularGuardianAccessControl.RETRY_ROLE(),
-      NEW_RETRY_GUARDIAN
-    );
+    granularGuardian.grantRole(granularGuardian.RETRY_ROLE(), NEW_RETRY_GUARDIAN);
 
     // Revoke retry role from the old guardian
-    GranularGuardianAccessControl(GRANULAR_GUARDIAN).revokeRole(
-      GranularGuardianAccessControl.RETRY_ROLE(),
-      oldRetryRoleGuardian
-    );
+    granularGuardian.revokeRole(granularGuardian.RETRY_ROLE(), oldRetryRoleGuardian);
   }
 }

--- a/tests/adi/ADITestBase.sol
+++ b/tests/adi/ADITestBase.sol
@@ -8,6 +8,7 @@ import {ChainHelpers, ChainIds} from 'solidity-utils/contracts/utils/ChainHelper
 import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
 import {ProxyHelpers} from 'aave-v3-origin/../tests/utils/ProxyHelpers.sol';
 
+import {GranularGuardianAccessControl} from 'adi/access_control/GranularGuardianAccessControl.sol';
 import {ICrossChainForwarder} from 'adi/interfaces/ICrossChainForwarder.sol';
 import {ICrossChainReceiver} from 'adi/interfaces/ICrossChainReceiver.sol';
 import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
@@ -54,8 +55,16 @@ contract ADITestBase is Test {
     uint256 optimalBandwidth;
   }
 
+  struct GranularGuardianRoles {
+    address[] retryGuardians;
+    address[] solveEmergencyGuardians;
+    address defaultAdmin;
+  }
+
   struct CCCConfig {
+    address guardian;
     address crossChainControllerImpl;
+    GranularGuardianRoles granularGuardianRoles;
     ReceiverConfigByChain[] receiverConfigs;
     ReceiverAdaptersByChain[] receiverAdaptersConfig;
     ForwarderAdaptersByChain[] forwarderAdaptersConfig;
@@ -84,6 +93,9 @@ contract ADITestBase is Test {
     bool forwarderAdapterConfigs;
     bool cccImplUpdate;
     bool optimalBandwidth;
+    bool guardian;
+    bool granularGuardianRoles;
+    bool owner;
     string reportName;
   }
 
@@ -417,6 +429,8 @@ contract ADITestBase is Test {
           forwarderAdapterConfigs: true,
           cccImplUpdate: true,
           optimalBandwidth: true,
+          guardian: true,
+          owner: true,
           reportName: reportName
         })
       );
@@ -438,7 +452,46 @@ contract ADITestBase is Test {
     if (snapshotParams.forwarderAdapterConfigs) _writeForwarderAdapters(path, config);
     if (snapshotParams.cccImplUpdate) _writeCCCImplUpdate(path, config);
     if (snapshotParams.optimalBandwidth) _writeOptimalBandwidth(path, config);
+    if (snapshotParams.guardian) _writeGuardian(path, config);
+    if (snapshotParams.granularGuardianRoles) _writeGranularGuardianRoles(path, config);
+    if (snapshotParams.owner) _writeOwner(path, config);
     return config;
+  }
+
+  function _writeGuardian(string memory path, CCCConfig memory config) internal {
+    string memory output = vm.serializeAddress('root', 'guardian', config.guardian);
+    vm.writeJson(output, path);
+  }
+
+  function _writeGranularGuardianRoles(string memory path, CCCConfig memory config) internal {
+    string memory granularGuardianRoles = 'granularGuardianRoles';
+    string memory content = '{}';
+    vm.serializeJson(granularGuardianRoles, '{}');
+    GranularGuardianRoles memory roles = config.granularGuardianRoles;
+    for (uint256 i = 0; i < roles.retryGuardians.length; i++) {
+      string memory key = vm.toString(roles.retryGuardians[i]);
+      vm.serializeJson(key, '{}');
+      string memory object;
+
+      object = vm.serializeString(key, 'retryGuardians', roles.retryGuardians[i]);
+      content = vm.serializeString(granularGuardianRoles, key, object);
+    }
+    for (uint256 i = 0; i < roles.solveEmergencyGuardians.length; i++) {
+      string memory key = vm.toString(roles.solveEmergencyGuardians[i]);
+      vm.serializeJson(key, '{}');
+      string memory object;
+      object = vm.serializeString(key, 'solveEmergencyGuardians', roles.solveEmergencyGuardians[i]);
+      content = vm.serializeString(granularGuardianRoles, key, object);
+    }
+
+    string memory defaultAdminKey = vm.toString(roles.defaultAdmin);
+    vm.serializeJson(defaultAdminKey, '{}');
+    string memory object;
+    object = vm.serializeString(defaultAdminKey, 'defaultAdmin', roles.defaultAdmin);
+    content = vm.serializeString(granularGuardianRoles, defaultAdminKey, object);
+
+    string memory output = vm.serializeString('root', 'granularGuardianRoles', content);
+    vm.writeJson(output, path);
   }
 
   function _writeOptimalBandwidth(string memory path, CCCConfig memory config) internal {
@@ -571,8 +624,32 @@ contract ADITestBase is Test {
     vm.writeJson(output, path);
   }
 
+  function _writeOwner(string memory path, CCCConfig memory config) internal {
+    string memory output = vm.serializeAddress('root', 'owner', config.owner);
+    vm.writeJson(output, path);
+  }
+
   function _getCCCConfig(address ccc) internal view returns (CCCConfig memory) {
     CCCConfig memory config;
+
+    // get guardian
+    config.guardian = OwnableWithGuardian(ccc).guardian();
+
+    // get granular guardian roles
+    address[] memory retryGuardians = GranularGuardianAccessControl(ccc).getRoleMembers(
+      GranularGuardianAccessControl.RETRY_ROLE()
+    );
+    address[] memory solveEmergencyGuardians = GranularGuardianAccessControl(ccc).getRoleMembers(
+      GranularGuardianAccessControl.SOLVE_EMERGENCY_ROLE()
+    );
+    address defaultAdmin = GranularGuardianAccessControl(ccc).getRoleAdmin(
+      GranularGuardianAccessControl.DEFAULT_ADMIN_ROLE()
+    );
+    config.granularGuardianRoles = GranularGuardianRoles({
+      retryGuardians: retryGuardians,
+      solveEmergencyGuardians: solveEmergencyGuardians,
+      defaultAdmin: defaultAdmin
+    });
 
     // get crossChainController implementation
     config.crossChainControllerImpl = ProxyHelpers

--- a/tests/adi/ADITestBase.sol
+++ b/tests/adi/ADITestBase.sol
@@ -434,7 +434,7 @@ contract ADITestBase is Test {
           cccImplUpdate: true,
           optimalBandwidth: true,
           guardian: true,
-          granularGuardianRoles: false, // TODO: enable once all guardians are migrated to granular guardian
+          granularGuardianRoles: true,
           owner: true,
           reportName: reportName
         })

--- a/tests/gg/GGRetryRoleMigrationTest.t.sol
+++ b/tests/gg/GGRetryRoleMigrationTest.t.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.0;
 import {Test} from 'forge-std/Test.sol';
 import {GranularGuardianAccessControl} from 'adi/access_control/GranularGuardianAccessControl.sol';
 import {ADITestBase} from '../adi/ADITestBase.sol';
-import {GGRetryRoleMigrationArgs} from '../../src/gg_payloads/RetryRoleMigrationPayload.sol';
+import {
+  GGRetryRoleMigrationArgs,
+  RetryRoleMigrationPayload
+} from '../../src/gg_payloads/RetryRoleMigrationPayload.sol';
 import {
   Arbitrum,
   Avalanche,
@@ -25,17 +28,37 @@ import {
   Sonic,
   Xlayer
 } from '../../scripts/payloads/gg/GG_retry_role_migration.s.sol';
+import {GovernanceV3Arbitrum} from 'aave-address-book/GovernanceV3Arbitrum.sol';
+import {GovernanceV3Avalanche} from 'aave-address-book/GovernanceV3Avalanche.sol';
+import {GovernanceV3Base} from 'aave-address-book/GovernanceV3Base.sol';
+import {GovernanceV3BNB} from 'aave-address-book/GovernanceV3BNB.sol';
+import {GovernanceV3Bob} from 'aave-address-book/GovernanceV3Bob.sol';
+import {GovernanceV3Celo} from 'aave-address-book/GovernanceV3Celo.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {GovernanceV3Gnosis} from 'aave-address-book/GovernanceV3Gnosis.sol';
+import {GovernanceV3Ink} from 'aave-address-book/GovernanceV3Ink.sol';
+import {GovernanceV3Linea} from 'aave-address-book/GovernanceV3Linea.sol';
+import {GovernanceV3Mantle} from 'aave-address-book/GovernanceV3Mantle.sol';
+import {GovernanceV3MegaEth} from 'aave-address-book/GovernanceV3MegaEth.sol';
+import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
+import {GovernanceV3Plasma} from 'aave-address-book/GovernanceV3Plasma.sol';
+import {GovernanceV3Polygon} from 'aave-address-book/GovernanceV3Polygon.sol';
+import {GovernanceV3Scroll} from 'aave-address-book/GovernanceV3Scroll.sol';
+import {GovernanceV3Sonic} from 'aave-address-book/GovernanceV3Sonic.sol';
+import {GovernanceV3XLayer} from 'aave-address-book/GovernanceV3XLayer.sol';
 
 abstract contract BaseGGRetryRoleMigrationTest is ADITestBase {
   address internal _payload;
   string internal NETWORK;
   uint256 internal immutable BLOCK_NUMBER;
+  address internal _granularGuardian;
+  address internal _newRetryGuardian;
 
-  function GRANULAR_GUARDIAN() internal view virtual returns (address);
   function CURRENT_RETRY_GUARDIAN() internal view virtual returns (address);
-  function NEW_RETRY_GUARDIAN() internal view virtual returns (address);
   function CROSS_CHAIN_CONTROLLER() internal view virtual returns (address);
 
+  function _getGranularGuardian() internal view virtual returns (address);
+  function _getNewRetryGuardian() internal view virtual returns (address);
   function _getDeployedPayload() internal virtual returns (address);
 
   function _getPayload() internal virtual returns (address);
@@ -49,6 +72,8 @@ abstract contract BaseGGRetryRoleMigrationTest is ADITestBase {
     vm.createSelectFork(vm.rpcUrl(NETWORK), BLOCK_NUMBER);
 
     _payload = _getPayload();
+    _granularGuardian = _getGranularGuardian();
+    _newRetryGuardian = _getNewRetryGuardian();
   }
 
   function test_defaultTest() public {
@@ -71,25 +96,21 @@ abstract contract BaseGGRetryRoleMigrationTest is ADITestBase {
   }
 
   function test_migrationToNewRetryGuardian() public {
-    address granularGuardian = GRANULAR_GUARDIAN();
     address currentRetryGuardian = CURRENT_RETRY_GUARDIAN();
-    address newRetryGuardian = NEW_RETRY_GUARDIAN();
 
-    GranularGuardianAccessControl gg = GranularGuardianAccessControl(granularGuardian);
+    GranularGuardianAccessControl gg = GranularGuardianAccessControl(_granularGuardian);
 
-    assertEq(gg.getRoleAdmin(gg.RETRY_ROLE()), currentRetryGuardian);
     assertEq(gg.getRoleMember(gg.RETRY_ROLE(), 0), currentRetryGuardian);
 
     executePayload(vm, address(_payload));
 
-    assertEq(gg.getRoleAdmin(gg.RETRY_ROLE()), newRetryGuardian);
-    assertEq(gg.getRoleMember(gg.RETRY_ROLE(), 0), newRetryGuardian);
+    assertEq(gg.getRoleMember(gg.RETRY_ROLE(), 0), _newRetryGuardian);
   }
 }
 
 // TODO: add block number
 contract ArbitrumTest is Arbitrum, BaseGGRetryRoleMigrationTest('arbitrum', 222622842) {
-  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+  function _getGranularGuardian() internal pure override returns (address) {
     return GovernanceV3Arbitrum.GRANULAR_GUARDIAN;
   }
 
@@ -112,10 +133,18 @@ contract ArbitrumTest is Arbitrum, BaseGGRetryRoleMigrationTest('arbitrum', 2226
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  } 
 }
 
 // TODO: add block number
 contract AvalancheTest is Avalanche, BaseGGRetryRoleMigrationTest('avalanche', 46727153) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Avalanche.GRANULAR_GUARDIAN;
+  }
+
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x3DBA1c4094BC0eE4772A05180B7E0c2F1cFD9c36; // BGD guardian
   }
@@ -135,10 +164,18 @@ contract AvalancheTest is Avalanche, BaseGGRetryRoleMigrationTest('avalanche', 4
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract BaseTest is Base, BaseGGRetryRoleMigrationTest('base', 43003513) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Base.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Base.CROSS_CHAIN_CONTROLLER;
   }
@@ -158,6 +195,10 @@ contract BaseTest is Base, BaseGGRetryRoleMigrationTest('base', 43003513) {
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0x7FDA7C3528ad8f05e62148a700D456898b55f8d2; // BGD guardian
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
@@ -165,6 +206,11 @@ contract BinanceTest is Binance, BaseGGRetryRoleMigrationTest('binance', 4035341
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3BNB.CROSS_CHAIN_CONTROLLER;
   }
+
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3BNB.GRANULAR_GUARDIAN;
+  }
+
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0xE8C5ab722d0b1B7316Cc4034f2BE91A5B1d29964; // BGD guardian
   }
@@ -179,10 +225,18 @@ contract BinanceTest is Binance, BaseGGRetryRoleMigrationTest('binance', 4035341
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract BobTest is Bob, BaseGGRetryRoleMigrationTest('bob', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Bob.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Bob.CROSS_CHAIN_CONTROLLER;
   }
@@ -202,10 +256,18 @@ contract BobTest is Bob, BaseGGRetryRoleMigrationTest('bob', 10000000) {
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0xdc62E0e65b2251Dc66404ca717FD32dcC365Be3A; // BGD guardian
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract CeloTest is Celo, BaseGGRetryRoleMigrationTest('celo', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Celo.GRANULAR_GUARDIAN;
+  }
+
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
     return 0xfD3a6E65e470a7D7D730FFD5D36a9354E8F9F4Ea; // BGD guardian
   }
@@ -225,10 +287,18 @@ contract CeloTest is Celo, BaseGGRetryRoleMigrationTest('celo', 10000000) {
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract EthereumTest is Ethereum, BaseGGRetryRoleMigrationTest('ethereum', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Ethereum.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Ethereum.CROSS_CHAIN_CONTROLLER;
   }
@@ -248,10 +318,18 @@ contract EthereumTest is Ethereum, BaseGGRetryRoleMigrationTest('ethereum', 1000
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract GnosisTest is Gnosis, BaseGGRetryRoleMigrationTest('gnosis', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Gnosis.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Gnosis.CROSS_CHAIN_CONTROLLER;
   }
@@ -270,10 +348,18 @@ contract GnosisTest is Gnosis, BaseGGRetryRoleMigrationTest('gnosis', 10000000) 
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract InkTest is Ink, BaseGGRetryRoleMigrationTest('ink', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Ink.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Ink.CROSS_CHAIN_CONTROLLER;
   }
@@ -293,10 +379,18 @@ contract InkTest is Ink, BaseGGRetryRoleMigrationTest('ink', 10000000) {
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract LineaTest is Linea, BaseGGRetryRoleMigrationTest('linea', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Linea.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Linea.CROSS_CHAIN_CONTROLLER;
   }
@@ -315,10 +409,18 @@ contract LineaTest is Linea, BaseGGRetryRoleMigrationTest('linea', 10000000) {
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 // TODO: add block number
 contract MantleTest is Mantle, BaseGGRetryRoleMigrationTest('mantle', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Mantle.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Mantle.CROSS_CHAIN_CONTROLLER;
   }
@@ -338,11 +440,19 @@ contract MantleTest is Mantle, BaseGGRetryRoleMigrationTest('mantle', 10000000) 
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 contract MegaethTest is Megaeth, BaseGGRetryRoleMigrationTest('megaeth', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3MegaEth.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
-    return GovernanceV3Megaeth.CROSS_CHAIN_CONTROLLER;
+    return GovernanceV3MegaEth.CROSS_CHAIN_CONTROLLER;
   }
 
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
@@ -359,6 +469,10 @@ contract MegaethTest is Megaeth, BaseGGRetryRoleMigrationTest('megaeth', 1000000
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
+  }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
   }
 }
 
@@ -377,6 +491,10 @@ contract MegaethTest is Megaeth, BaseGGRetryRoleMigrationTest('megaeth', 1000000
 // }
 
 contract OptimismTest is Optimism, BaseGGRetryRoleMigrationTest('optimism', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Optimism.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Optimism.CROSS_CHAIN_CONTROLLER;
   }
@@ -396,9 +514,17 @@ contract OptimismTest is Optimism, BaseGGRetryRoleMigrationTest('optimism', 1000
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 contract PlasmaTest is Plasma, BaseGGRetryRoleMigrationTest('plasma', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Plasma.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Plasma.CROSS_CHAIN_CONTROLLER;
   }
@@ -413,13 +539,22 @@ contract PlasmaTest is Plasma, BaseGGRetryRoleMigrationTest('plasma', 10000000) 
 
   function _getPayload() internal override returns (address) {
     GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 contract PolygonTest is Polygon, BaseGGRetryRoleMigrationTest('polygon', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Polygon.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Polygon.CROSS_CHAIN_CONTROLLER;
   }
@@ -434,13 +569,22 @@ contract PolygonTest is Polygon, BaseGGRetryRoleMigrationTest('polygon', 1000000
 
   function _getPayload() internal override returns (address) {
     GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
   }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 contract ScrollTest is Scroll, BaseGGRetryRoleMigrationTest('scroll', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Scroll.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Scroll.CROSS_CHAIN_CONTROLLER;
   }
@@ -455,9 +599,14 @@ contract ScrollTest is Scroll, BaseGGRetryRoleMigrationTest('scroll', 10000000) 
 
   function _getPayload() internal override returns (address) {
     GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
+  }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
   }
 }
 
@@ -476,6 +625,10 @@ contract ScrollTest is Scroll, BaseGGRetryRoleMigrationTest('scroll', 10000000) 
 // }
 
 contract SonicTest is Sonic, BaseGGRetryRoleMigrationTest('sonic', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3Sonic.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
     return GovernanceV3Sonic.CROSS_CHAIN_CONTROLLER;
   }
@@ -490,15 +643,23 @@ contract SonicTest is Sonic, BaseGGRetryRoleMigrationTest('sonic', 10000000) {
 
   function _getPayload() internal override returns (address) {
     GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
   }
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
+  }
 }
 
 contract XlayerTest is Xlayer, BaseGGRetryRoleMigrationTest('xlayer', 10000000) {
+  function _getGranularGuardian() internal pure override returns (address) {
+    return GovernanceV3XLayer.GRANULAR_GUARDIAN;
+  }
+
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
-    return GovernanceV3Xlayer.CROSS_CHAIN_CONTROLLER;
+    return GovernanceV3XLayer.CROSS_CHAIN_CONTROLLER;
   }
 
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
@@ -515,5 +676,9 @@ contract XlayerTest is Xlayer, BaseGGRetryRoleMigrationTest('xlayer', 10000000) 
       newRetryGuardian: NEW_RETRY_GUARDIAN()
     });
     return _deployPayload(args);
+  }
+
+  function _getNewRetryGuardian() internal pure override returns (address) {
+    return NEW_RETRY_GUARDIAN();
   }
 }

--- a/tests/gg/GGRetryRoleMigrationTest.t.sol
+++ b/tests/gg/GGRetryRoleMigrationTest.t.sol
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {GranularGuardianAccessControl} from 'adi/access_control/GranularGuardianAccessControl.sol';
+import {ADITestBase} from '../adi/ADITestBase.sol';
+import {GGRetryRoleMigrationArgs} from '../../src/gg_payloads/RetryRoleMigrationPayload.sol';
+import {Arbitrum} from '../../scripts/gg/network_scripts/GGRetryRoleMigrationNetworkDeploys.s.sol';
+
+abstract contract BaseGGRetryRoleMigrationTest is ADITestBase {
+  address internal _payload;
+  string internal NETWORK;
+  uint256 internal immutable BLOCK_NUMBER;
+
+  function GRANULAR_GUARDIAN() internal view virtual returns (address);
+  function CURRENT_RETRY_GUARDIAN() internal view virtual returns (address);
+  function NEW_RETRY_GUARDIAN() internal view virtual returns (address);
+  function CROSS_CHAIN_CONTROLLER() internal view virtual returns (address);
+
+  function _getDeployedPayload() internal virtual returns (address);
+
+  function _getPayload() internal virtual returns (address);
+
+  constructor(string memory network, uint256 blockNumber) {
+    NETWORK = network;
+    BLOCK_NUMBER = blockNumber;
+  }
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl(NETWORK), BLOCK_NUMBER);
+
+    _payload = _getPayload();
+  }
+
+  function test_defaultTest() public {
+    defaultTest(
+      string.concat('gg_retry_role_migration', NETWORK),
+      CROSS_CHAIN_CONTROLLER(),
+      address(_payload),
+      false,
+      vm
+    );
+  }
+
+  function test_samePayloadAddress() public {
+    RetryRoleMigrationPayload deployedPayload = RetryRoleMigrationPayload(_getDeployedPayload());
+    RetryRoleMigrationPayload predictedPayload = RetryRoleMigrationPayload(_getPayload());
+
+    assertEq(predictedPayload.GRANULAR_GUARDIAN(), deployedPayload.GRANULAR_GUARDIAN());
+    assertEq(predictedPayload.NEW_RETRY_GUARDIAN(), deployedPayload.NEW_RETRY_GUARDIAN());
+    assertEq(address(predictedPayload), address(deployedPayload));
+  }
+
+  function test_migrationToNewRetryGuardian() public {
+    address granularGuardian = GRANULAR_GUARDIAN();
+    address currentRetryGuardian = CURRENT_RETRY_GUARDIAN();
+    address newRetryGuardian = NEW_RETRY_GUARDIAN();
+
+    GranularGuardianAccessControl gg = GranularGuardianAccessControl(granularGuardian);
+
+    assertEq(gg.getRoleAdmin(gg.RETRY_ROLE()), currentRetryGuardian);
+    assertEq(gg.getRoleMember(gg.RETRY_ROLE(), 0), currentRetryGuardian);
+
+    executePayload(vm, address(_payload));
+
+    assertEq(gg.getRoleAdmin(gg.RETRY_ROLE()), newRetryGuardian);
+    assertEq(gg.getRoleMember(gg.RETRY_ROLE(), 0), newRetryGuardian);
+  }
+}
+
+// TODO: add block number
+contract ArbitrumTest is Arbitrum, BaseGGRetryRoleMigrationTest('arbitrum', 222622842) {
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Arbitrum.GRANULAR_GUARDIAN;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x1Fcd437D8a9a6ea68da858b78b6cf10E8E0bF959; // BGD guardian
+  }
+
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Arbitrum.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract AvalancheTest is Avalanche, BaseGGRetryRoleMigrationTest('avalanche', 46727153) {
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x3DBA1c4094BC0eE4772A05180B7E0c2F1cFD9c36; // BGD guardian
+  }
+
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Avalanche.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract BaseTest is Base, BaseGGRetryRoleMigrationTest('base', 43003513) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Base.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x7FDA7C3528ad8f05e62148a700D456898b55f8d2; // BGD guardian
+  }
+}
+
+// TODO: add block number
+contract BinanceTest is Binance, BaseGGRetryRoleMigrationTest('binance', 40353415) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3BNB.CROSS_CHAIN_CONTROLLER;
+  }
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xE8C5ab722d0b1B7316Cc4034f2BE91A5B1d29964; // BGD guardian
+  }
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract BobTest is Bob, BaseGGRetryRoleMigrationTest('bob', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Bob.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xdc62E0e65b2251Dc66404ca717FD32dcC365Be3A; // BGD guardian
+  }
+}
+
+// TODO: add block number
+contract CeloTest is Celo, BaseGGRetryRoleMigrationTest('celo', 10000000) {
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xfD3a6E65e470a7D7D730FFD5D36a9354E8F9F4Ea; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Celo.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract EthereumTest is Ethereum, BaseGGRetryRoleMigrationTest('ethereum', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Ethereum.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xb812d0944f8F581DfAA3a93Dda0d22EcEf51A9CF; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract GnosisTest is Gnosis, BaseGGRetryRoleMigrationTest('gnosis', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Gnosis.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xcb8a3E864D12190eD2b03cbA0833b15f2c314Ed8; // BGD guardian
+  }
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract InkTest is Ink, BaseGGRetryRoleMigrationTest('ink', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Ink.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x81D251dA015A0C7bD882918Ca1ec6B7B8E094585; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract LineaTest is Linea, BaseGGRetryRoleMigrationTest('linea', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Line.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xfD3a6E65e470a7D7D730FFD5D36a9354E8F9F4Ea; // BGD guardian
+  }
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// TODO: add block number
+contract MantleTest is Mantle, BaseGGRetryRoleMigrationTest('mantle', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Mantle.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x0686f59Cc2aEc1ccf891472Dc6C89bB747F6a4A7; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+contract MegaethTest is Megaeth, BaseGGRetryRoleMigrationTest('megaeth', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Megaeth.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x58528Cd7B8E84520df4D3395249D24543f431c21; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// contract Metis is GG_retry_role_migration {
+//   function GRANULAR_GUARDIAN() internal pure override returns (address) {
+//     return GovernanceV3Metis.GRANULAR_GUARDIAN;
+//   }
+
+//   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x9853589F951D724D9f7c6724E0fD63F9d888C429; // BGD guardian
+//   }
+
+//   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+//   }
+// }
+
+contract OptimismTest is Optimism, BaseGGRetryRoleMigrationTest('optimism', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Optimism.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x3A800fbDeAC82a4d9c68A9FA0a315e095129CDBF; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+contract PlasmaTest is Plasma, BaseGGRetryRoleMigrationTest('plasma', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Plasma.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xdc62E0e65b2251Dc66404ca717FD32dcC365Be3A; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+contract PolygonTest is Polygon, BaseGGRetryRoleMigrationTest('polygon', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Polygon.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0xbCEB4f363f2666E2E8E430806F37e97C405c130b; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+contract ScrollTest is Scroll, BaseGGRetryRoleMigrationTest('scroll', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Scroll.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x4aAa03F0A61cf93eA252e987b585453578108358; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+// contract Soneium is GG_retry_role_migration {
+//   function GRANULAR_GUARDIAN() internal pure override returns (address) {
+//     return GovernanceV3Soneium.GRANULAR_GUARDIAN;
+//   }
+
+//   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0xdc62E0e65b2251Dc66404ca717FD32dcC365Be3A; // BGD guardian
+//   }
+
+//   function NEW_RETRY_GUARDIAN() internal pure override returns (address) {
+//     return 0x0000000000000000000000000000000000001000; // TODO: add new guardian
+//   }
+// }
+
+contract SonicTest is Sonic, BaseGGRetryRoleMigrationTest('sonic', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Sonic.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x7837d7a167732aE41627A3B829871d9e32e2e7f2; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}
+
+contract XlayerTest is Xlayer, BaseGGRetryRoleMigrationTest('xlayer', 10000000) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Xlayer.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {
+    return 0x734c3fF8DE95c3745770df69053A31FDC92F2526; // BGD guardian
+  }
+
+  function _getDeployedPayload() internal pure override returns (address) {
+    return address(0); // TODO: add deployed payload address
+  }
+
+  function _getPayload() internal override returns (address) {
+    GGRetryRoleMigrationArgs memory args = GGRetryRoleMigrationArgs({
+      granularGuardian: GRANULAR_GUARDIAN(),
+      newRetryGuardian: NEW_RETRY_GUARDIAN()
+    });
+    return _deployPayload(args);
+  }
+}

--- a/tests/gg/GGRetryRoleMigrationTest.t.sol
+++ b/tests/gg/GGRetryRoleMigrationTest.t.sol
@@ -5,7 +5,26 @@ import {Test} from 'forge-std/Test.sol';
 import {GranularGuardianAccessControl} from 'adi/access_control/GranularGuardianAccessControl.sol';
 import {ADITestBase} from '../adi/ADITestBase.sol';
 import {GGRetryRoleMigrationArgs} from '../../src/gg_payloads/RetryRoleMigrationPayload.sol';
-import {Arbitrum} from '../../scripts/gg/network_scripts/GGRetryRoleMigrationNetworkDeploys.s.sol';
+import {
+  Arbitrum,
+  Avalanche,
+  Base,
+  Binance,
+  Bob,
+  Celo,
+  Ethereum,
+  Gnosis,
+  Ink,
+  Linea,
+  Mantle,
+  Megaeth,
+  Optimism,
+  Plasma,
+  Polygon,
+  Scroll,
+  Sonic,
+  Xlayer
+} from '../../scripts/payloads/gg/GG_retry_role_migration.s.sol';
 
 abstract contract BaseGGRetryRoleMigrationTest is ADITestBase {
   address internal _payload;
@@ -279,7 +298,7 @@ contract InkTest is Ink, BaseGGRetryRoleMigrationTest('ink', 10000000) {
 // TODO: add block number
 contract LineaTest is Linea, BaseGGRetryRoleMigrationTest('linea', 10000000) {
   function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
-    return GovernanceV3Line.CROSS_CHAIN_CONTROLLER;
+    return GovernanceV3Linea.CROSS_CHAIN_CONTROLLER;
   }
 
   function CURRENT_RETRY_GUARDIAN() internal pure override returns (address) {


### PR DESCRIPTION
On this pr we create the Payloads to migrate the RetryRole of the Granular Guardian from BGD to the new Guardian address.
It contains:
- Payload
- Tests
- Deploy Scripts

TODO:
Once the payloads are deployed, the tests must be updated with the payload addresses and the blockNumbers (bigger than deployment block). This way once tests are run, the diffs will be generated with the diffs in the retry role address.

- Provably you will need to update aave-helpers lib to latest version (to have the most updated address book addresses)
- the deploy command is `make gg-retry-role-migration` (remember to specify the networks needed for deployment on the Makefile)

AIP:
To create the AIP, link this url (with blob) to the AIP for tests, payload and diffs, so that reviewers and people can check the validity.

Permissions Book:
With the payloads deployed, on permissions book they can be used to check state post execution (no need for the payloads to be registered). 