### PR TITLE
fix: missing scroll GranularGuardian migration

### DIFF
--- a/scripts/helpers/GenerateGuardianMigrationCalldata.s.sol
+++ b/scripts/helpers/GenerateGuardianMigrationCalldata.s.sol
@@ -13,6 +13,7 @@ import {GovernanceV3Metis} from 'aave-address-book/GovernanceV3Metis.sol';
 import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
 import {GovernanceV3Arbitrum} from 'aave-address-book/GovernanceV3Arbitrum.sol';
 import {GovernanceV3Base} from 'aave-address-book/GovernanceV3Base.sol';
+import {GovernanceV3Scroll} from 'aave-address-book/GovernanceV3Scroll.sol';
 
 contract GenerateGuardianMigrationCalldata is Script {
   struct NetworkConfig {
@@ -46,7 +47,7 @@ contract GenerateGuardianMigrationCalldata is Script {
   }
 
   function _getNetworks() internal pure returns (NetworkConfig[] memory) {
-    NetworkConfig[] memory networks = new NetworkConfig[](9);
+    NetworkConfig[] memory networks = new NetworkConfig[](10);
 
     networks[0] = NetworkConfig({
       name: 'Ethereum',
@@ -100,6 +101,12 @@ contract GenerateGuardianMigrationCalldata is Script {
       name: 'Base',
       crossChainController: GovernanceV3Base.CROSS_CHAIN_CONTROLLER,
       granularGuardian: GovernanceV3Base.GRANULAR_GUARDIAN
+    });
+
+    networks[9] = NetworkConfig({
+      name: 'Scroll',
+      crossChainController: GovernanceV3Scroll.CROSS_CHAIN_CONTROLLER,
+      granularGuardian: GovernanceV3Scroll.GRANULAR_GUARDIAN
     });
 
     return networks;

--- a/tests/access_control/GranularGuardianMigrationTest.t.sol
+++ b/tests/access_control/GranularGuardianMigrationTest.t.sol
@@ -14,6 +14,7 @@ import {GovernanceV3Metis} from 'aave-address-book/GovernanceV3Metis.sol';
 import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
 import {GovernanceV3Arbitrum} from 'aave-address-book/GovernanceV3Arbitrum.sol';
 import {GovernanceV3Base} from 'aave-address-book/GovernanceV3Base.sol';
+import {GovernanceV3Scroll} from 'aave-address-book/GovernanceV3Scroll.sol';
 
 abstract contract BaseGranularGuardianMigrationTest is Test {
   string internal NETWORK;
@@ -250,5 +251,19 @@ contract PolygonGranularGuardianMigrationTest is BaseGranularGuardianMigrationTe
 
   function AAVE_GOVERNANCE_GUARDIAN() internal pure override returns (address) {
     return GovernanceV3Polygon.GOVERNANCE_GUARDIAN;
+  }
+}
+
+contract ScrollGranularGuardianMigrationTest is BaseGranularGuardianMigrationTest('scroll', 33257912) {
+  function CROSS_CHAIN_CONTROLLER() internal pure override returns (address) {
+    return GovernanceV3Scroll.CROSS_CHAIN_CONTROLLER;
+  }
+
+  function GRANULAR_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Scroll.GRANULAR_GUARDIAN;
+  }
+
+  function AAVE_GOVERNANCE_GUARDIAN() internal pure override returns (address) {
+    return GovernanceV3Scroll.GOVERNANCE_GUARDIAN;
   }
 }


### PR DESCRIPTION
Call data for the Scroll network migration from BGD guardian to GranularGuardian

  Network: Scroll
  Target (CCC): 0x03073D3F4769f6b6604d616238fD6c636C99AD0A
  New Guardian: 0xa835707d28e6C37C49d661742f2Fb5987367cEd4
  Calldata:
  0xfc525395000000000000000000000000a835707d28e6c37c49d661742f2fb5987367ced4